### PR TITLE
Note for the config of php5 under apache 2.4

### DIFF
--- a/fr/source/admin_guide/installation/linux.rst
+++ b/fr/source/admin_guide/installation/linux.rst
@@ -38,7 +38,7 @@ Depuis le fichier ZIP
    cd /var/www/
    # options
    MYAPP=lizmap-web-client
-   VERSION=2.10.0
+   VERSION=2.11.0
    # récupération de l'archive via wget
    wget https://github.com/3liz/lizmap-web-client/archive/$VERSION.zip
    # on dézippze l'archive

--- a/fr/source/admin_guide/installation/server_configuration.rst
+++ b/fr/source/admin_guide/installation/server_configuration.rst
@@ -95,6 +95,8 @@ Configuration de php5
 
 On utilise dans cet exemple le mpm-worker d'Apache. On doit donc configurer manuellement l'activation de php5.
 
+.. warning:: In Apache 2.4, the file ``php.conf`` is in ``/etc/apache2/conf-available/``. Then the configuration must be activated with: ``a2enmod php``
+
 .. code-block:: bash
 
    cat > /etc/apache2/conf.d/php.conf << EOF
@@ -112,7 +114,6 @@ On utilise dans cet exemple le mpm-worker d'Apache. On doit donc configurer manu
    </Files>
    EOF
 
-   
 Configuration du mpm-worker
 -----------------------------
 


### PR DESCRIPTION
In general, I find the split between the two chapters (``linux.rst`` and ``server_configuration.rst``) quite confusing. Also the generic conf is done for debs, so why not merging the two chapters?