### PR TITLE
searchAttributes example

### DIFF
--- a/source/install/ldap.rst
+++ b/source/install/ldap.rst
@@ -52,7 +52,7 @@ from the profiles.ini.php.dist.
     searchUserBaseDN="dc=XY,dc=fr"
     searchUserFilter="(&(objectClass=posixAccount)(uid=%%LOGIN%%))"
     bindUserDN="uid=%?%,ou=users,dc=XY,dc=fr"
-    searchAttributes="uid:login,givenName:firstname,sn:lastname,mail:email"
+    searchAttributes="uid:login,givenName:firstname,sn:lastname,mail:email,organization:organization,street:street,postcode:postcode,city:city"
     searchGroupFilter=
     searchGroupProperty="cn"
     searchGroupBaseDN=""


### PR DESCRIPTION
While configuring LDAP for lizmap auth i notice a little problem. There are various fields in db (jauth.db in my case) that can't be null and the use of the doc example for LDAP produce errors for all the fileds not mapped and it can be only seen debugging the ldap connection.

So if I can, i suggest to modify lizmap-doc (ldap settings) line for searchAttributes as ...
from => searchAttributes="uid:login,givenName:firstname,sn:lastname,mail:email"
to => searchAttributes="uid:login,givenName:firstname,sn:lastname,mail:email,organization:organization,street:street,postcode:postcode,city:city"
[lizmap 3.2.3 on debian9, apache2, postggres9.6]