### PR TITLE
explicit the required files to publish project

### DIFF
--- a/source/admin/lizmap-configuration.rst
+++ b/source/admin/lizmap-configuration.rst
@@ -87,6 +87,7 @@ You should check the checkbox "Use a proxy server" and fill these fields:
   to a local server that serves map backgrounds etc... You have at least to set
   it with "localhost,127.0.0.1".
 
+.. _declare-repositories:
 
 Repositories
 ============

--- a/source/install/index.rst
+++ b/source/install/index.rst
@@ -14,3 +14,4 @@ Installing and upgrading Lizmap
   ldap
   advanced_install
   upgrade
+  project_repository

--- a/source/install/linux.rst
+++ b/source/install/linux.rst
@@ -116,6 +116,7 @@ https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-p
 
 https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-apache-in-ubuntu-16-04
 
+.. _install-data-folder:
 
 Create directories for data
 ===========================

--- a/source/install/project_repository.rst
+++ b/source/install/project_repository.rst
@@ -1,0 +1,13 @@
+
+.. _install-sync-tool:
+
+==============================================
+Add an access for synchronizing projects files
+==============================================
+
+.. note:: If you are working locally, as Lizmap Web Client is installed on the same machine you use for QGIS, you do not need to *synchronize* your files. This configuration should only exist for testing.
+
+Once your Lizmap is working correctly, you need to setup some workflow to allow publishers to synchronize their projects files (.qgs, .qgs.cfg) on the server.
+Precisly, you need to grant an acces to the folder you defined during installation (:ref:`install-data-folder`) and setup in administration (:ref:`declare-repositories`).
+
+You can use any tool and synchronization protocol (FTP, FTPS, SFTP, DAV, rsync, unison, etc). The folder must be accessible for lizmap and qgis process (which read the project files) and your synchronisation set-up (ftp user, rsync process, ...).

--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -2,6 +2,8 @@
 Introduction
 ============
 
+ .. _intro-lizmap-archi:
+
 Lizmap architecture
 ===================
 

--- a/source/publish/quick_start/index.rst
+++ b/source/publish/quick_start/index.rst
@@ -8,3 +8,4 @@ This is quick start guide to help you how to publish your first dataset on Lizma
 
   project_for_web
   lizmap_configuration
+  publish

--- a/source/publish/quick_start/publish.rst
+++ b/source/publish/quick_start/publish.rst
@@ -1,0 +1,30 @@
+===============
+Publish the map
+===============
+
+.. contents::
+   :depth: 3
+
+Reminder of Lizmap architecture
+===============================
+
+.. image:: /images/architecture.jpg
+   :align: center
+
+
+
+
+
+Duplicate local files to Lizmap repository 
+==========================================
+
+
+**Lizmap is based on repositories system**. To publish a map in Lizmap, it is sufficient to ensure that the contents of the local directory containing the data and QGIS projects **be reproduced exactly** identical in the corresponding server repository.
+
+For this, it is necessary **to synchronize the local directory with that of the server** each time you update the QGIS project, modify the Lizmap configuration with the plugin, or add files in the local directory.
+
+At least two files are required : the QGIS project file (.qgs) and the corresponding Lizmap configuration file (.qgs.cfg).
+
+.. note:: If you are working locally, as Lizmap Web Client is installed on the same machine you use for QGIS, you do not need to *synchronize* your files. This configuration should only exist for testing.
+
+.. note:: You can use any tool and synchronization protocol (FTP, FTPS, SFTP, rsync, unison, etc), if you can master the tool and have access to the Lizmap server configuration.

--- a/source/publish/quick_start/publish.rst
+++ b/source/publish/quick_start/publish.rst
@@ -5,18 +5,7 @@ Publish the map
 .. contents::
    :depth: 3
 
-Reminder of Lizmap architecture
-===============================
-
-.. image:: /images/architecture.jpg
-   :align: center
-
-
-
-
-
-Duplicate local files to Lizmap repository 
-==========================================
+.. note:: Reminder of Lizmap publication wokflow, see :ref:`intro-lizmap-archi`
 
 
 **Lizmap is based on repositories system**. To publish a map in Lizmap, it is sufficient to ensure that the contents of the local directory containing the data and QGIS projects **be reproduced exactly** identical in the corresponding server repository.
@@ -25,6 +14,4 @@ For this, it is necessary **to synchronize the local directory with that of the 
 
 At least two files are required : the QGIS project file (.qgs) and the corresponding Lizmap configuration file (.qgs.cfg).
 
-.. note:: If you are working locally, as Lizmap Web Client is installed on the same machine you use for QGIS, you do not need to *synchronize* your files. This configuration should only exist for testing.
-
-.. note:: You can use any tool and synchronization protocol (FTP, FTPS, SFTP, rsync, unison, etc), if you can master the tool and have access to the Lizmap server configuration.
+See the set-up chosen by admin during installation : :ref:`install-sync-tool`


### PR DESCRIPTION
Since 3.6, the FTP part is not detailled, the quick start steps doesn't detail the publish part, i made some reword