### PR TITLE
Update documentation about installing demo

### DIFF
--- a/source/install/linux.rst
+++ b/source/install/linux.rst
@@ -381,15 +381,6 @@ to set the url of qgis map server and other things.
    cp localconfig.ini.php.dist localconfig.ini.php
    cd ../../..
 
-In case you want to enable the demo repositories, just add to :file:`localconfig.ini.php` the following:
-
-.. code-block:: ini
-
-   [modules]
-   lizmap.installparam=demo
-
-
-
 Launching the installer
 -----------------------
 
@@ -401,6 +392,14 @@ After creating configuration files, you can launch the installer
 
 It will finished the installation, and will create all SQL tables needed by Lizmap.
 
+Adding some demonstration projects
+----------------------------------
+
+If you want to test Lizmap with some demonstration projects, you must install ``unzip`` and either ``wget`` or ``curl.
+
+.. code-block:: bash
+
+    lizmap/install/reset.sh --keep-config --demo
 
 First test
 ----------


### PR DESCRIPTION
Following what is written in https://github.com/3liz/lizmap-web-client/blob/master/INSTALL.md#test

Should fix https://github.com/3liz/lizmap-web-client/issues/2234 and fix https://github.com/3liz/lizmap-web-client/issues/2222


Backport 3.5 as well ?