### PR TITLE
Start a "Layer properties" section with a page if a tab is useful in the LWC context

### DIFF
--- a/source/publish/configuration/index.rst
+++ b/source/publish/configuration/index.rst
@@ -10,7 +10,6 @@ Settings in Lizmap doesn't occur only in Lizmap QGIS plugin. Some settings are s
   project_for_web
   project_thumbnail
   project
-  layer
   legend
   popup
   actions

--- a/source/publish/configuration/project.rst
+++ b/source/publish/configuration/project.rst
@@ -1,5 +1,5 @@
-Project configuration
-=====================
+Project properties
+==================
 
 .. contents::
    :depth: 3

--- a/source/publish/index.rst
+++ b/source/publish/index.rst
@@ -9,6 +9,7 @@ This guide is for the GIS technician who want to publish some data in Lizmap web
 
   quick_start/index
   lizmap_plugin/index
+  layer_properties/index
   configuration/index
   publish
   customization/index

--- a/source/publish/layer_properties/attributes_form.rst
+++ b/source/publish/layer_properties/attributes_form.rst
@@ -1,27 +1,11 @@
 .. include:: ../../substitutions.rst
 
-Layer configuration
-===================
+Attributes Form
+===============
 
 .. contents::
    :depth: 3
 
-These settings are in :menuselection:`Layer properties`.
-
-.. _layer_qgis_server:
-
-QGIS Server tab
----------------
-
-In :menuselection:`Layer Properties --> QGIS Server`, you can set different settings for QGIS Server :
-
-* :guilabel:`Short name` is a machine readable name for the layer.
-* :guilabel:`dataUrl` is the URL to a HTML or PDF presenting the data. It can be a link to the open data portal webpage.
-
-If the link is empty in :menuselection:`Lizmap --> Layers` dialog, the link in Lizmap will be automatically populated
-by the Lizmap plugin from set in this tab.
-
-You can use the |refresh_svg| button in Lizmap to pick this value.
 
 .. _alias_on_fields:
 
@@ -128,11 +112,3 @@ Lizmap can reproduce several behavior configured in QGIS :
     As shown in the video above, it's not possible anymore, natively, to have the combobox showing the area clicked
     automatically after the click on the map. The combobox has an empty value as a first item but has still a single
     value in the dropdown menu with the name of the neighbourhood clicked on the map.
-
-.. _server_side_simplification:
-
-Server side simplification
---------------------------
-
-For PostGIS layers, you can enable server side simplification. This in :menuselection:`Layer properties --> Rendering` for each layers.
-You can change the default behavior for next new layer in :menuselection:`QGIS General properties --> Rendering`.

--- a/source/publish/layer_properties/display.rst
+++ b/source/publish/layer_properties/display.rst
@@ -1,0 +1,9 @@
+.. include:: ../../substitutions.rst
+
+Display
+=======
+
+HTML Map Tip
+------------
+
+Read the :ref:`qgis-popup`.

--- a/source/publish/layer_properties/index.rst
+++ b/source/publish/layer_properties/index.rst
@@ -1,0 +1,13 @@
+================
+Layer Properties
+================
+
+These settings are in the :menuselection:`Layer properties` dialog.
+
+.. toctree::
+  :maxdepth: 3
+
+  attributes_form
+  display
+  rendering
+  qgis_server

--- a/source/publish/layer_properties/qgis_server.rst
+++ b/source/publish/layer_properties/qgis_server.rst
@@ -1,0 +1,19 @@
+.. include:: ../../substitutions.rst
+
+.. _layer_qgis_server:
+
+QGIS Server
+===========
+
+Metadata
+--------
+
+In :menuselection:`Layer Properties --> QGIS Server`, you can set different settings for QGIS Server :
+
+* :guilabel:`Short name` is a machine readable name for the layer.
+* :guilabel:`dataUrl` is the URL to a HTML or PDF presenting the data. It can be a link to the open data portal webpage.
+
+If the link is empty in :menuselection:`Lizmap --> Layers` dialog, the link in Lizmap will be automatically populated
+by the Lizmap plugin from set in this tab.
+
+You can use the |refresh_svg| button in Lizmap to pick this value.

--- a/source/publish/layer_properties/rendering.rst
+++ b/source/publish/layer_properties/rendering.rst
@@ -1,0 +1,12 @@
+.. include:: ../../substitutions.rst
+
+Rendering
+=========
+
+.. _server_side_simplification:
+
+Server side simplification
+--------------------------
+
+For PostGIS layers, you can enable server side simplification. This in :menuselection:`Layer properties --> Rendering` for each layers.
+You can change the default behavior for next new layer in :menuselection:`QGIS General properties --> Rendering`.

--- a/source/publish/lizmap_plugin/editing.rst
+++ b/source/publish/lizmap_plugin/editing.rst
@@ -92,6 +92,11 @@ Please refer to the QGIS documentation to see how to create a spatial layer in a
 - .. include:: ../../shared/move_up_down_layer.rst
 - .. include:: ../../shared/field_alias.rst
 
+Configuring the form
+--------------------
+
+The form in Lizmap is inherited from the :guilabel:`Layer Properties`. Read the :ref:`form`.
+
 Reusing data of edition layers
 ------------------------------
 


### PR DESCRIPTION
## Problem 
Might be tricky to organize a documentation for LWC for some subjects (sometimes in vector layer properties, sometimes in the plugin only, sometimes in both)

For instance : 

* **popups** : 
  * either an "automatic popup" (not linked to the QGIS project)
  * or if "HTML maptip", then it's totally linked to the "Vector layer properties → Rendering tab" 
* **Editing**, two steps are needed : 
  * one step in the plugin, pretty self explanatory this step
  * The other bigger step is in the vector layer properties dialog

Also, the current "Layer configuration" page is grouping all tabs, not easy to navigate/discover.
https://docs.lizmap.com/current/fr/publish/configuration/layer.html

## Proposal

Similar to the "Lizmap plugin" section, showing a page for each tab in the plugin, in the correct order, I propose to add a new section "Layer Properties".

It would allow us to add more easily some tips in the different tabs of the "Layer properties" dialog.

I agree, for instance, "Layer properties → Display → HTML MapTip" is only linked to to the "Popup concept chapter" → HTML Maptip anchor. But I think it allows people to search easily by the "Vector Layer properties" section.

The **configuration** section has still some general chapters.

![image](https://github.com/3liz/lizmap-documentation/assets/1609292/ecda87c9-e776-4dad-8878-940253f89411)


