### PR TITLE
Add permalink with popup feature

### DIFF
--- a/source/publish/configuration/index.rst
+++ b/source/publish/configuration/index.rst
@@ -17,4 +17,5 @@ Settings in Lizmap doesn't occur only in Lizmap QGIS plugin. Some settings are s
   expression
   print
   spatial_search
+  permalink
   optimization

--- a/source/publish/configuration/permalink.rst
+++ b/source/publish/configuration/permalink.rst
@@ -1,0 +1,44 @@
+Permalink
+=========
+
+.. contents::
+   :depth: 3
+
+Zoom on an object when opening the map
+--------------------------------------
+
+Some URL parameters are available to be able to zoom in on one or more objects and display their popup:
+
+* ``layer``, layer name in WFS and WMS services
+* ``filter``, layer filter to initiate the zoom
+* ``popup=true``, boolean to display the popup(s) of the filtered objects
+
+The layer and filter parameters will be used for WFS and WMS type queries, so make sure that these are well compatible
+with the 2 types of services.
+
+For instance, we would like to reuse the map of Montpellier showing cadastral by
+providing a customized link opening the popup from the :guilabel:`Park of Peyrou` in the city center.
+
+This park has ``340172000BX0079`` for its unique ID in the field ``geo_parcelle``, layer ``parcelle``.
+
+Therefore, we need to add in the URL above :
+
+.. code-block:: ini
+
+    layer=parcelle
+    filter=%22geo_parcelle%22%20%3D%20%27340172000BX0079%27
+    popup=true
+
+It gives this final result :
+
+https://demo.lizmap.com/lizmap/index.php/view/map?repository=miscellaneous&project=flatgeobuf&layer=parcelle&filter=%22geo_parcelle%22%20%3D%20%27340172000BX0079%27&popup=true
+
+For your information, we can have the value of the filter with the help of the JavaScript console in your web browser :kbd:`F12` :
+
+.. code-block:: javascript
+
+    encodeURIComponent("\"geo_parcelle\" = '340172000BX0079'")`
+
+.. tip::
+    You should check **other** URL parameters which can be in the URL already. They can alter the behavior of the
+    described feature, for instance ``bbox=``.

--- a/source/publish/configuration/popup.rst
+++ b/source/publish/configuration/popup.rst
@@ -318,3 +318,8 @@ Here an example:
 .. image:: /images/popup_display_children.jpg
    :align: center
    :width: 80%
+
+Permalink with a popup
+----------------------
+
+See the chapter `permalink <permalink.html>`_.

--- a/source/publish/lizmap_plugin/attribute_table.rst
+++ b/source/publish/lizmap_plugin/attribute_table.rst
@@ -53,7 +53,7 @@ To add a layer to this tool:
 
         - In the *vector layer properties dialog* of the QGIS vector layer, in the *Fields* tab, you can uncheck the
           checkbox of the column **WFS** for the fields to unpublish. This means this fields will not be published via
-          the WFS protocol. This is the **simplest and safiest way** to restrict the publication to some fields
+          the WFS protocol. This is the **simplest and safest way** to restrict the publication to some fields
           (for example to get rid of sensitive fields)
         - You can use this **Fields to hide** option to **hide** the given fields in the attribute table display. The
           hidden fields won't be visible for the end user, but will still be available for Lizmap Web Client.


### PR DESCRIPTION
 Add permalink with popup feature

This feature was not documented, the only way is to know these params was to read the 3.6 changelog https://www.3liz.com/news/lizmap-web-client-3-6.html

Before it was an additional JS script https://github.com/3liz/lizmap-javascript-scripts/#tools, which is broken since this feature in core, for instance https://github.com/3liz/lizmap-web-client/issues/3690