### PR TITLE
Add documentation for geometry copy/paste, DXF export, atlas printing…

### DIFF
--- a/source/publish/configuration/print.rst
+++ b/source/publish/configuration/print.rst
@@ -81,6 +81,28 @@ Layout with an atlas when using a popup
 
 Read in the popup chapter, :ref:`print-layout-atlas`
 
+Atlas printing from the attribute table
+---------------------------------------
+
+When a layer has atlas print layouts configured and the attribute table is enabled, users can select multiple features
+in the attribute table and print them together as a single atlas PDF.
+
+To enable this:
+
+1. Create a print layout with atlas enabled on the layer.
+2. Publish the layout in the :guilabel:`Layouts` panel of the Lizmap plugin.
+3. Enable the :guilabel:`Attribute table` for the same layer (see :ref:`attribute_table`).
+
+The *Atlas* button will then appear in the attribute table toolbar for that layer. If multiple atlas layouts are
+configured for the layer, the button shows as a dropdown menu.
+
+PDF filename
+^^^^^^^^^^^^
+
+The generated PDF filename is derived from the ``filenamePattern`` expression configured in the QGIS atlas settings.
+For a single feature, the expression is evaluated with that feature's attributes. For multiple features, a fallback
+name in the format ``ProjectName_LayoutName.pdf`` is used.
+
 Adding your own images in a layout
 ----------------------------------
 

--- a/source/publish/lizmap_plugin/basemap.rst
+++ b/source/publish/lizmap_plugin/basemap.rst
@@ -67,6 +67,24 @@ The licenses are available at the following URLs:
 * *Bing*: https://www.microsoft.com/en-us/maps/product
 * *IGN*: https://geoservices.ign.fr/catalogue
 
+.. _basemap-exclude-single-wms:
+
+Exclude basemaps from single WMS requests
+------------------------------------------
+
+When the option :guilabel:`Single tile` is enabled for layers, Lizmap groups them into a single WMS request to
+QGIS Server. If your basemap is a local raster layer (for example a Cloud-Optimized GeoTIFF), including it in this
+combined request can significantly degrade performance because the raster must be converted from its native format
+(e.g. JPEG) to PNG for the combined image.
+
+To avoid this, you can enable :guilabel:`Exclude basemaps from single WMS` in the Lizmap plugin. When enabled,
+basemap layers are always rendered as separate requests in their native image format, while other layers continue
+to be combined into a single WMS request. This can reduce rendering times dramatically (e.g. from 3 seconds to
+300 milliseconds for local raster basemaps).
+
+This option is available in the :guilabel:`Map options` panel and defaults to disabled (off) to maintain backward
+compatibility with existing projects.
+
 Scale with external base layer
 ------------------------------
 

--- a/source/publish/lizmap_plugin/dxf_export.rst
+++ b/source/publish/lizmap_plugin/dxf_export.rst
@@ -1,0 +1,48 @@
+.. include:: ../../substitutions.rst
+
+.. _dxf-export:
+
+DXF export — Export map data to DXF
+====================================
+
+.. contents::
+   :depth: 3
+
+Principle
+---------
+
+The DXF export feature allows users to export the current map view as a DXF file via QGIS Server. This is useful for
+users who need to work with the map data in CAD software such as AutoCAD.
+
+The feature is disabled by default and must be explicitly enabled in the Lizmap plugin. You can control which user
+groups are allowed to use the export and which layers can be exported.
+
+Prerequisites
+-------------
+
+* The layers you want to make available for DXF export must have **WFS** capabilities enabled.
+* .. include:: ../../shared/wfs_layer.rst
+
+Configuring the tool
+--------------------
+
+In the Lizmap plugin, open the :guilabel:`DXF Export` panel:
+
+1. Check :guilabel:`Allow DXF export` to enable the feature for the project.
+2. Optionally, enter a comma-separated list of Lizmap group IDs in :guilabel:`Allowed groups` to restrict access.
+   If left empty, all authenticated users can use the export (when the feature is enabled).
+3. The layer table is automatically populated with all WFS-enabled layers. Use the checkboxes to enable or disable
+   individual layers for DXF export.
+
+Configuration storage
+^^^^^^^^^^^^^^^^^^^^^
+
+The configuration is stored in the ``.qgs.cfg`` file:
+
+* ``options.dxfExportEnabled`` (boolean, default: ``false``) — enables or disables the DXF export feature.
+* ``options.allowedGroups`` (string, comma-separated group IDs) — restricts access to specific Lizmap groups.
+* ``dxfExport.layers[]`` (array of ``{layerId, enabled}`` objects) — controls which layers are available for export.
+
+.. note::
+    Existing projects without DXF export configuration will default to having the feature disabled, ensuring
+    backward compatibility.

--- a/source/publish/lizmap_plugin/editing.rst
+++ b/source/publish/lizmap_plugin/editing.rst
@@ -105,6 +105,21 @@ to see how to create a spatial layer in a PostgreSQL database.
 - .. include:: ../../shared/move_up_down_layer.rst
 - .. include:: ../../shared/field_alias.rst
 
+Geometry copy and paste
+-----------------------
+
+Users can copy the geometry of an existing feature while creating or editing a new feature. This allows them to reuse
+shapes from other layers without having to redraw them manually.
+
+For a layer to appear as a source when copying geometries, it must:
+
+* Be **visible** on the map
+* Have **WFS** capabilities enabled (see :ref:`publish OGC services <wfs-layer>`)
+* Have a **popup** enabled
+
+No additional configuration in the Lizmap plugin is needed. The copy geometry button is automatically available in the
+digitizing toolbar when an edition session is active.
+
 Configuring the form
 --------------------
 

--- a/source/publish/lizmap_plugin/index.rst
+++ b/source/publish/lizmap_plugin/index.rst
@@ -23,3 +23,4 @@ This section is listing panels available in the Lizmap QGIS plugin.
   atlas
   locate_by_layer
   tooltip
+  dxf_export

--- a/source/publish/lizmap_plugin/map_options.rst
+++ b/source/publish/lizmap_plugin/map_options.rst
@@ -59,6 +59,18 @@ Initial map extent
 * the maximal map extent is specified in the *QGIS server* tab of *Project Properties* window. The data will not be displayed if they are outside it
 * by default, the initial extent is the maximal one.
 
+Single WMS layer
+----------------
+
+* :guilabel:`Load layers as single WMS image`: when enabled, Lizmap combines all non-basemap layers into a single WMS
+  request to QGIS Server instead of requesting each layer individually. This can reduce the number of requests and
+  simplify rendering, but the resulting image is always in PNG format regardless of individual layer settings.
+
+* :guilabel:`Exclude basemaps from single WMS`: when :guilabel:`Load layers as single WMS image` is enabled, this
+  option excludes basemap layers from the combined request. Basemaps are then rendered separately in their native
+  image format (e.g. JPEG), which can greatly improve performance for local raster basemaps such as Cloud-Optimized
+  GeoTIFFs. See :ref:`basemap-exclude-single-wms` for more details.
+
 Map interface
 -------------
 

--- a/source/user/dxf_export.rst
+++ b/source/user/dxf_export.rst
@@ -1,0 +1,25 @@
+DXF export
+==========
+
+The DXF export feature allows you to export the current map view as a DXF file, which can be opened in CAD software such as AutoCAD or QGIS.
+
+.. note:: This feature is only available if the map publisher has enabled it. Only layers with WFS capabilities enabled can be exported.
+
+Exporting the current map view
+------------------------------
+
+#. Click on the *DXF export* button in the menu bar.
+#. A dialog appears with the following options:
+
+   - **Scale**: Choose the export scale. This controls the level of detail in the output.
+   - **Symbology mode**: Select how layer styling is handled in the DXF file:
+
+     + *Symbol layer*: Preserves the full complexity of the QGIS symbology. Each symbol layer of a feature is exported as a separate DXF entity. For example, a road styled with a thick black line and a thin white line on top (cased road) will produce two distinct DXF elements.
+     + *Feature*: Each feature is exported as a single DXF entity. Complex multi-layer symbology is simplified to one representation per feature, which results in a simpler DXF file.
+     + *None*: Exports geometries without any symbology information.
+
+   - **Layers**: Select which layers to include in the export. Only WFS-enabled layers are available for selection.
+
+#. Click *Export* to generate the DXF file. The file will be downloaded automatically with the naming format ``ProjectName_Timestamp.dxf``.
+
+.. note:: The layer order in the exported DXF file is determined by the QGIS project configuration and cannot be changed from the web client.

--- a/source/user/edition.rst
+++ b/source/user/edition.rst
@@ -70,3 +70,20 @@ If you want to remove a point on a geometry, you must hover it and type *Del* on
 .. image:: /images/user-guide-27-edition-digitizing.jpg
    :align: center
    :scale: 80%
+
+Copy existing geometry
+----------------------
+
+When creating or editing a feature, you can copy the geometry of an existing feature from any visible layer that is published as WFS. This is useful when you need to create features with similar shapes to existing ones.
+
+#. Start editing a layer by clicking *Add* or selecting an existing feature to edit.
+#. Click the *Copy existing geometry* button in the digitizing toolbar. The draw tool is temporarily deactivated and the cursor changes to a crosshair.
+#. Click on the map at the location of the feature whose geometry you want to copy. Lizmap will query all visible WFS-enabled layers at that position.
+#. A popup appears listing the features found at the click location. Only features with a compatible geometry type are shown (e.g. when editing a polygon layer, only polygon features are listed).
+#. Hover over a row in the popup to highlight the corresponding feature on the map.
+#. Click on a row to copy that geometry into your current editing session.
+#. The copied geometry is applied and the draw tool is reactivated. You can continue to modify the geometry or save the feature directly.
+
+To cancel the copy operation, click the *Copy existing geometry* button again to deactivate it.
+
+.. tip:: Only layers that are both visible and published as WFS can be queried. If a visible layer does not appear in the feature list, contact your administrator to ensure the layer has WFS capabilities enabled.

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -16,3 +16,4 @@ This guide is for the end user, when using the web client.
   printing
   attribute_table
   edition
+  dxf_export

--- a/source/user/printing.rst
+++ b/source/user/printing.rst
@@ -30,3 +30,29 @@ To begin building the print file, you can click on *Print*. You will get a PDF f
 .. image:: /images/user-guide-18-print-result.jpg
    :align: center
    :scale: 80%
+
+Atlas printing
+--------------
+
+When the map publisher has configured atlas print layouts for a layer, you can generate a PDF for individual features or a selection of features.
+
+Atlas printing from the popup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you click on a feature on the map and its popup appears, a print link is available if an atlas layout has been configured for this layer. Clicking the link generates a PDF for that single feature.
+
+See :ref:`print-layout-atlas` for more details on how this is configured.
+
+Atlas printing from the attribute table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also print an atlas PDF for multiple features at once from the attribute table.
+
+#. Open the attribute table for a layer that has atlas layouts configured.
+#. Select one or more features using the selection tools (click the *Select* button on each row, or use the search and *Select searched lines* button).
+#. Click the *Atlas* button in the attribute table toolbar. If the layer has multiple atlas layouts configured, a dropdown menu lets you choose which layout to use.
+#. A PDF file is generated containing all selected features as an atlas. The file is downloaded automatically.
+
+The PDF filename is derived from the atlas filename expression configured in the QGIS print layout. For a single feature, the filename evaluates the expression with that feature's attributes (e.g. ``Commune_Paris.pdf``). When multiple features are selected, a fallback name in the format ``ProjectName_LayoutName.pdf`` is used.
+
+.. note:: The *Atlas* button is only visible in the attribute table toolbar for layers that have at least one atlas print layout configured by the map publisher.


### PR DESCRIPTION
…, and basemap WMS exclusion

User documentation:
- Geometry copy & paste workflow in the edition digitizing toolbar
- DXF export with scale, symbology mode, and layer options
- Atlas printing from popup and attribute table with multi-feature support

Publisher documentation:
- DXF export plugin panel: enable/disable, allowed groups, per-layer configuration
- Geometry copy/paste prerequisites (WFS + popup required on source layers)
- Atlas printing from attribute table setup and PDF filename expression
- Exclude basemaps from single WMS requests for improved raster performance
- Single WMS layer and basemap exclusion options in Map Options


I will add screenshots once a pre-release of 3.10 and the lizmap-plugin are available!